### PR TITLE
Add "⚠" launch support for HumbleBundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Xbox                                              | ✅               | ✅     
 [Uplay][uplay]                                    | ✅               | ❌           | ✅       | ✅
 ***Community, Stores***
 [Discord][discord]                                | ✅               | ⬛           | ⬛       | ✅
-[Humble Bundle][humble]                           | ❌               | ❌           | ❌       | ❌
+[Humble Bundle][humble]                           | ⚠               | ❌           | ❌       | ❌
 [Itch.io][itch]                                   | ⚠                | ⬜           | ⬜       | ⬜
 [Rockstar Game Launcher][rockstar] (showed as Riot) | ⚠                | ❌           | ❌       | ✅
 [Twitch.tv][twitch]                               | ✅               | ❌           | ❌       | ❌


### PR DESCRIPTION
humblebundle integration tries to find game execs by scanning:
a) windows registry
b) directories given in config.ini
Once found, launching should work fine.