### PR TITLE
Updated the Rockstar plugin information.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Xbox                                              | ✅               | ✅     
 [Discord][discord]                                | ✅               | ⬛           | ⬛       | ✅
 [Humble Bundle][humble]                           | ⚠               | ❌           | ❌       | ❌
 [Itch.io][itch]                                   | ⚠                | ⬜           | ⬜       | ⬜
-[Rockstar Game Launcher][rockstar] (showed as Riot) | ⚠                | ❌           | ❌       | ✅
+[Rockstar Games Launcher][rockstar]               | ✅                | ❌           | ❌       | ✅
 [Twitch.tv][twitch]                               | ✅               | ❌           | ❌       | ❌
 [Wargaming.net][wargaming]                        | ✅               | ❌           | ⬜       | ✅
 ***Community, Games***


### PR DESCRIPTION
With the latest release of the Rockstar plugin, the platform ID has been correctly set to Rockstar. In addition, the method for obtaining the user's owned games has been overhauled. The details for this implementation can be found [here](https://github.com/tylerbrawl/Galaxy-Plugin-Rockstar/issues/2#issuecomment-539746753).