### PR TITLE
Added basic game time support for Rockstar.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Xbox                                              | ✅               | ✅     
 [Discord][discord]                                | ✅               | ⬛           | ⬛       | ✅
 [Humble Bundle][humble]                           | ⚠               | ❌           | ❌       | ❌
 [Itch.io][itch]                                   | ⚠                | ⬜           | ⬜       | ⬜
-[Rockstar Games Launcher][rockstar]               | ✅                | ❌           | ❌       | ✅
+[Rockstar Games Launcher][rockstar]               | ✅                | ❌           | ⚠       | ✅
 [Twitch.tv][twitch]                               | ✅               | ❌           | ❌       | ❌
 [Wargaming.net][wargaming]                        | ✅               | ❌           | ⬜       | ✅
 ***Community, Games***


### PR DESCRIPTION
The latest version of the Rockstar Games Launcher plugin now records the user's game time manually. However, since I have not been able to find out how to retrieve the user's game time statistic from the actual launcher, the user must launch the game through Galaxy 2.0 for the time to be tracked. This is why the feature is marked as "works with issues," rather than as "working."

I will leave it up to you as to whether or not you wish to incorporate this change to the list.